### PR TITLE
Add system theme detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "wl-web",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
@@ -16,7 +16,6 @@
         "astro-particles": "^2.10.0",
         "bootstrap-icons": "^1.11.3",
         "image-compare-viewer": "^1.6.2",
-        "particles.js": "^2.0.0",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
         "rehype-toc": "^3.0.2",
@@ -5512,11 +5511,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-    },
-    "node_modules/particles.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/particles.js/-/particles.js-2.0.0.tgz",
-      "integrity": "sha512-8e0JIqkRbMMPlFBnF9f+92hX1s07jdkd3tqB8uHE9L+cwGGjIYjQM7QLgt0FQ5MZp6SFFYYDm/Y48pqK3ZvJOQ=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "astro-particles": "^2.10.0",
     "bootstrap-icons": "^1.11.3",
     "image-compare-viewer": "^1.6.2",
-    "particles.js": "^2.0.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "rehype-toc": "^3.0.2",

--- a/src/components/DefaultHead.astro
+++ b/src/components/DefaultHead.astro
@@ -1,5 +1,6 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="darkreader-lock"> <!-- Disable Dark Reader as we have dark mode -->
 </head>
 
 <div class="carouseltop">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -201,16 +201,37 @@ const { isGuide, isMain } = Astro.props;
 <script is:inline>
 const themeColorButton = document.getElementById('themeColor');
 const languageOverride = localStorage.getItem('languageOverride');
-const savedMode = localStorage.getItem('color-mode');
 
+// Listener to check and set theme preference
 document.addEventListener('DOMContentLoaded', function () {
 
-	// Check user preference
-if (savedMode === 'dark') {
-    enableDarkMode();
-  } else {
-    enableLightMode();
-  }
+	// If color-mode has no setting, we will set it through localStorage
+	if (localStorage.getItem('color-mode') === null) {
+		if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+			localStorage.setItem('color-mode', 'dark');
+		} else {
+			localStorage.setItem('color-mode', 'light');
+		}
+	}
+
+	const savedMode = localStorage.getItem('color-mode');
+
+	// Now we can get the savedMode and guarantee it, setting the theme accordingly (or if we couldn't check, fallback to light)
+	if (savedMode === 'dark') {
+		enableDarkMode();
+	} else {
+		enableLightMode();
+	}
+
+	// We will then add another listener that will listen for changes and update
+	window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+		if (event.matches) {
+			enableDarkMode();
+		} else {
+			enableLightMode();
+		}
+	});
+
 });
 
   // Function to enable dark mode


### PR DESCRIPTION
This adds support for setting the current theme based on the system theme, if a user doesn't already have a preferred theme set through the site's button. It also automatically switches theme depending on the system changing theme. Additionally disables Dark Reader for users who have it so it won't conflict.