### PR TITLE
Add troubleshooting for error 109139

### DIFF
--- a/src/content/guide/Problemsolving.md
+++ b/src/content/guide/Problemsolving.md
@@ -29,6 +29,16 @@ heroImage: "../../img/guidebg-3.png"
 
 <div class="error">Error Code: 51330 <span class="badge bg-warning">Internet Error</span><h4>Make sure that your Internet Connection to your Wii is working by doing a Connection Test. if it's Successful, run the Patcher again. If it Fails, Use a different Internet Connection.</h4><hr></div>
 
+<div class="error">Error: 109139 <span class="badge bg-warning">Any Channel</span>
+     <h4>WiiConnect24 service isn’t activated on your console. Go to Wii Settings → WiiConnect24 and agree to it’s terms
+          of use. If it reports that “WiiConnect24 and Wii Shop Channel service is not currently being offered”, try
+          changing your Wii’s country setting (for European Wiis, “United Kingdom” is recommended). If it succeeds, you
+          may attempt to switch back to your actual country, though it may not be supported in all
+          regions.<br />If the issue persists, ensure that “Standby Connection” is enabled in WiiConnect24
+          settings and in Priiloader (if you use it) and “Parental Controls” are turned off.</h4>
+     <hr>
+</div>
+
 <div class="error">Error Code: 354 <span class="badge bg-primary">Wii Room</span><h4>Please <a href="https://discord.gg/wiilink" class="text-primary"><i class="fa-brands fa-discord" style="margin-right:5px;"></i> Join our Discord</a> server or message us on our Twitter account with more information. This error is server-side, so please let us know what happened for it to occur!</h4><hr></div>
 
 <div class="error">PAL crashes <span class="badge bg-danger">Japanese channels</span><h4>Unfortunately, this is a known issue. We're aware of many crashes for PAL Region consoles. We continue to work on a solution for this, thank you for your patience.</h4><hr></div>


### PR DESCRIPTION
*Adding "WiiConnect24 settings disabled" (`109139`) to the troubleshooting guide.*

![Screenshot from 2024-04-20 16-44-44.png](https://github.com/WiiLink24/web/assets/84882649/5a1b97d7-f86f-43e4-9dbd-ae75beb83a44)

The 109139 error seems quite common on WiiLink’s Discord, so I thought it’d would be nice to have it on the support page. \
I tried to follow closely what I saw from conversations on WiiLink24 Discord and wrote down the common steps:

- Enable WiiConnect24 in the settings<sup>[3]</sup> and agree to WC24 EULA<sup>[1],[2],[8]</sup>
    - If the page says *"WiiConnect24 and Wii Shop Channel service is not currently being offered"*, change the Wii’s country to something else (pref. "United Kingdom"<sup>[5]</sup>) and try again. If it works, you can try setting it to your actual country<sup>[1]</sup> (though your country may not be supported)
- Is using Priiloader, ensure "WiiConnect24 Standby Connection" is enabled in Priiloader<sup>[6]</sup>
- Parental settings should be turned off<sup>[7]</sup>

Please, let me know if I missed something (other ways to resolve/get the error code, some troubleshooting step I missed, bad "Any Channel" category or anything). Also, please check my grammar and phrasing, English is my third language. :)

[1]: https://discord.com/channels/206934458954153984/1222220031413457017
[2]: https://discord.com/channels/206934458954153984/288361557044494337/959872961588895804
[3]: https://discord.com/channels/206934458954153984/288361557044494337/1226419235786592307
[4]: https://discord.com/channels/206934458954153984/206934458954153984/1215989612883742782
[5]: https://discord.com/channels/206934458954153984/206934458954153984/1190562660417273906
[6]: https://discord.com/channels/206934458954153984/1167090766401773578/1167123408471986256
[7]: https://discord.com/channels/206934458954153984/1064299436995522590/1064312458208100403
[8]: https://discord.com/channels/206934458954153984/288361557044494337/975572938231263313