### PR TITLE
Major update to the Install page (+ others)

### DIFF
--- a/src/content/guide/Install.md
+++ b/src/content/guide/Install.md
@@ -39,21 +39,21 @@ heroImage: "../../img/guidebg-1.png"
 
 ### vWii (Wii U) ONLY
 
-<l class="notice warn fullwidth">If you're on vWii, these steps are required. Otherwise, [skip to Section I.](#section-i---patching-wads)</l>
+<l class="notice warn smallwidth">If you're on vWii, these steps are required. Otherwise, [skip to Section I.](#section-i---patching-wads)</l>
 
-1. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Download the `Priiloader.zip` file from [here](https://oscwii.org/library/app/priiloader)
-2. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Unzip the `Priiloader.zip` file and copy the apps folder to your SD Card or USB Drive.
-3. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Download the `LoadPriiloader.zip` from [here](https://oscwii.org/library/app/LoadPriiloader).
+1. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Download the `Priiloader Installer` from [here](https://oscwii.org/library/app/priiloader).
+2. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Open the `Priiloader.zip` file and copy the apps folder to your SD Card or USB Drive.
+3. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Download `Load Priiloader` from [here](https://oscwii.org/library/app/LoadPriiloader).
 4. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Unzip the `LoadPriiloader.zip` file and copy the apps folder to the root of your SD Card or USB Drive.
 5. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Visit [this site](https://garyodernichts.github.io/priiloader-patch-gen/) to generate a Priiloader patch that will fix a timestamp issue.
 6. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Follow the instructions on the page then copy the result.
 7. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> On your SD Card or USB Drive, traverse to `apps/priiloader` and open `hacks_hash.ini`
-8. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Paste the patch from step 6 at the bottom of the `hacks_hash.ini` Save the file, then proceed to `Step 9`
+8. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Paste the patch from `Step 6` at the bottom of the `hacks_hash.ini` Save the file, then proceed to `Step 9`
 9. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Launch `Priiloader`.
 10. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Follow the installation steps.
 11. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Launch `Load Priiloader`
 12. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Using your Wii Remote, go to `System Menu Hacks`.
-13. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Enable `Fix NWC24iSetUniversalTime` and if you're on the vWii enable `Wii System Settings via Options Button` and `Always enable WiiConnect24 on boot`. (Feel free to enable others.)
+13. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Enable `Fix NWC24iSetUniversalTime` from the menu. If you're on a Wii U, enable `Permanent vWii System Settings`, `Wii System Settings via Options Button`, and `Create message via Calendar button`. (Feel free to enable other options while you're in this menu)
 14. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Scroll down to `save settings` and press A, then press B to go back to the main menu of Priiloader.
 15. <i style="margin-bottom:13px; margin-right:8px; font-size:25px;"></i> Return to the system menu.
 
@@ -66,33 +66,45 @@ heroImage: "../../img/guidebg-1.png"
 
 ### Section I - Patching WADs
 
-> [If you want to see detailed instructions on how to install the WADs, click here!](#section-ii---installing-wads-and-patching-mail)
+</br>
 
-1. Visit the [ WiiLink Patcher releases page](https://github.com/WiiLink24/WiiLink24-Patcher/releases) and download the correct patcher for your operating system.
-2. On Windows, run `WiiLink_Patcher_Windows_v2.X.X.exe`. <br>
-   On MacOS, right click the `WiiLink_Patcher_macOS-<arch>_v2.X.X` file in Finder and click Open. <br>
-   On Linux, open a Terminal, type `bash ` (space included), then drag the file onto the Terminal window. It should look like this: `bash /path/to/WiiLink_Patcher_Linux-<arch>_v2.X.X`
+> [If you want to see detailed instructions on how to install the WADs, click here!](#section-ii---installing-wads)
+
+</br>
+
+1. Visit the [WiiLink Patcher releases page](https://github.com/WiiLink24/WiiLink24-Patcher/releases) and download the correct patcher for your operating system.
+2. On `Windows`, run `WiiLink_Patcher_Windows_v2.X.X.exe`. <br>
+
+   On `MacOS`, right click the `WiiLink_Patcher_macOS-<arch>_v2.X.X` file in Finder and click Open. <br>
+
+   On `Linux`, open a Terminal, type `bash ` (space included), then drag the file onto the Terminal window. It should look like this: `bash /path/to/WiiLink_Patcher_Linux-<arch>_v2.X.X`
 
 > **For Linux and MacOS Users:** Replace `<arch>` with either `x64` or `arm64` depending on your system architecture.
 
 3. Choose your installation setup:
+
+</br>
+
+### Express Installation
    - Press `1` for `Express Install Setup`. Follow the steps below:
      1. Select your region for the WiiConnect24 channels.
      2. Select whether or not you would like to install the WiiLink channels.
      3. Select what language you would like for the WiiLink channels as well as your preferred Food Channel version if you chose to install them.
      4. Select your console platform.
      5. At the `Insert SD Card / USB Drive (if applicable)` step, press `1` to begin patching.
+
+### Custom Installation
    - Press `2` for `Custom Install Setup`. Follow the steps below:
      1. Select which channels you would like to install out of the list.
      2. Select your console platform.
      3. At the `Insert SD Card / USB Drive (if applicable)` step, press `1` to begin patching.
-4. It may take a moment for the patcher to download the files to your SD Card or USB Drive.
-5. Once it's done, you can safely close the patcher. All of the files are ready on your SD Card.
-6. If it did not copy everything automatically to your SD Card or USB Device, copy the `WAD` and `apps` folder next to the `WiiLink Patcher` file to your SD Card or USB Device.
+     4. It may take a moment for the patcher to download the files to your SD Card or USB Drive.
+     5. Once it's done, you can safely close the patcher. All of the files are ready on your SD Card.
+     6. If it did not copy everything automatically to your SD Card or USB Device, copy the `WAD` and `apps` folder next to the `WiiLink Patcher` file to your SD Card or USB Device.
 
 </br>
 
-### Section II - Installing WADs and Patching Mail
+### Section II - Installing WADs and Patching `Wii Mail`
 
 1. Put your SD card or USB drive in your Wii.
 2. Launch the Homebrew Channel on your Wii.
@@ -109,28 +121,30 @@ heroImage: "../../img/guidebg-1.png"
 <hr style="border-top:2px solid var(--border-color);">
 </br>
 
-### Section III (Optional) - Connecting to DNS and adding your Personal Information to the Address Information settings (SPD)
+## Section III (Optional) - Connecting to DNS and using the Address Information settings (SPD)
 
-## Connecting to DNS
+</br>
 
-<l class="notice info fullwidth">This step is optional, but it's recommended as it allows additional services to function.</l>
+### Connecting to DNS
+
+<l class="notice info smallwidth">This step is optional, but it's recommended as it allows additional services to function.</l>
 
 1. Go to the Wii Settings --> Internet --> Connection Settings --> the Connection that you're using --> Change Settings.
 
 2. Make your way to the "Auto-Obtain DNS" setting.
 
-<l class="notice info fullwidth">Take note that the "Auto-Obtain IP Address" and "Auto-Obtain DNS" settings both look similar, so be sure that you're on the DNS setting.</l>
+<l class="notice info smallwidth">Take note that the "Auto-Obtain IP Address" and "Auto-Obtain DNS" settings both look similar, so be sure that you're on the DNS setting.</l>
 
 3. Once you made sure that you're on the DNS setting, Click on "No", then "Advanced Settings".
 
-Set your Primary DNS to --> 167.86.108.126<br>
+Set your Primary DNS to --> 167.235.229.36<br>
 Set your Secondary DNS to --> 1.1.1.1
 
 4. After you're done setting up the DNS, save the changes and let the system perform the Connection Test.
 
 5. If the Connection Test is successful, make your way back to the second page of the system settings.
 
-<l class="notice generic fullwidth">If the Connection Test failed, use a different Internet Connection or try again.</l>
+<l class="notice generic smallwidth">If the Connection Test failed, use a different Internet Connection or try again.</l>
 
 6. Select WiiConnect24 then set "WiiConnect24" and "Standby Connection" to On.
 
@@ -140,13 +154,15 @@ Set your Secondary DNS to --> 1.1.1.1
 
 9. Once you read the EULA, Click on "I Accept".
 
+</br>
+
 ## Adding Personal Information
 
-<l class="notice generic fullwidth">WiiLink never stores your personal data. For more information on what is used, read our [Privacy Policy](/privacy-policy).</l>
+<l class="notice generic smallwidth">WiiLink never stores your personal data. For more information on what is used, read our [Privacy Policy](/privacy-policy).</l>
 
-<l class="notice info fullwidth">Adding your personal information to the Address Information Settings will allow the Photo Prints Channel to send images to your email, and the Food Channel to deliver the food to your house.</l>
+<l class="notice info smallwidth">Adding your personal information to the Address Information Settings will allow the Photo Prints Channel to send images to your email, and the Food Channel to deliver the food to your house.</l>
 
-<l class="notice warn fullwidth">You are responsible for entering your correct Address Information. Failure to do so may result in emails and/or orders not succeeding.</l>
+<l class="notice warn smallwidth">You are responsible for entering your correct Address Information. Failure to do so may result in emails and/or orders not succeeding.</l>
 
 ### Photo Prints Channel
 

--- a/src/content/guide/board.md
+++ b/src/content/guide/board.md
@@ -1,6 +1,6 @@
 ---
 title: Wii Message Board
-pubDate: 2024-01-24
+pubDate: 2024-06-11
 icon: fa-solid fa-chalkboard
 ---
 
@@ -17,55 +17,36 @@ icon: fa-solid fa-chalkboard
 </br>
 </br>
 
-### Installation guide
+## Installation guide
 
-<l class="notice info fullwidth">This software is included with your regular WiiLink install.</l>
 
-<l class="notice generic fullwidth">Make sure your SD Card/USB Drive is connected to your Computer in order for the Patcher to automatically send your files to your Wii's SD Card/USB Drive.</l>
 
-1. Open the WiiLink Mail Patcher application inside the Homebrew Channel.
+<l class="notice info smallwidth">This software is standardly included after using the "Express" option on the WiiLink Patcher. To figure out how to use it, click <a href="https://www.wiilink24.com/guide/install/">here</a>.</l>
+
+</br>
+
+1. Open the Mail-Patcher application from the Homebrew Channel.
 
 2. Follow the on-screen instructions.
 
 3. Once the patcher is finished, you can return to the Wii Menu.
 
-<l class="notice success fullwidth">Congrats! You've installed the Wii Mail Service on your Console! You can use the service to your hearts content once again!</l>
+</br>
+
+<l class="notice success smallwidth">Congratulations! You've patched Wii Mail on your Console! You can use the service to your hearts content once again!</l>
 ___
 
-## Receiving Mail from the service
 
-<l class="notice info fullwidth">This step is optional, but it's recommended so you can get news about the service on your Wii. </l>
+## Receiving Mail from the service with our DNS
 
-1. Go to the Wii Settings --> Internet --> Connection Settings --> the Connection that you're using --> Change Settings.
+<l class="notice info fullwidth">This step is completely optional, but recommended so you can get service news directly from your Wii! You can view the steps on how to use the DNS <a href="https://www.wiilink24.com/guide/install/">here.</a> </l>
 
-2. Make your way to the "Auto-Obtain DNS" setting.
-
-<l class="notice info fullwidth">Take note that the "Auto-Obtain IP Address" and "Auto-Obtain DNS" settings both look similar, so be sure that you're on the DNS setting.</l>
-
-3. Once you made sure that you're on the DNS setting, Click on "No", then "Advanced Settings".
-
-Set your Primary DNS to --> 167.86.108.126 <br>
-Set your Secondary DNS to --> 1.1.1.1
-
-4. After you get done setting up the DNS, save the changes and let the system perform the Connection Test.
-
-5. If the Connection Test is successful, make your way back to the second page of the system settings.
-
-<l class="notice generic fullwidth">If the Connection Test failed, use a different Internet Connection or try again.</l>
-
-6. Select WiiConnect24 then set "WiiConnect24" and "Standby Connection" to On.
-
-7. Go back to the 1st page of the "Internet" page, then select "User Agreements", then select "Yes".
-
-8. Allow the EULA to load. The developers recommended that you read the EULA, as it gives information about the service. If you do not see the WiiLink logo on the EULA, the DNS will not work on your network. If you want to enable it, you can use the <a href="https://github.com/RiiConnect24/DNS-Server">DNS Server application</a>.
-
-9. Once you read the EULA, Click on "I Accept".
-
-<l class="notice success fullwidth">Congrats! You've getting news about the service on the Wii Message Borad! You can stay informed about the service once again!</l>
 ___
-<i id="troubleshooting-questions"></i>
 
 ## Troubleshooting & Questions
 
-"I'm getting error -110211 or another error when trying to use the RiiConnect24 Mail Patcher, or I may have been a former user of the WiiLink Mail service.
-> Please join the WiiLink Discord Server for support, you may need to have your Wii Number removed on the database side in order to remedy this issue.
+</br>
+
+### "I'm getting error -110211 'Duplicate Registration' or another error when trying to use the Mail-Patcher, or I may have been a former user of the WiiLink Mail service."
+
+> Please join the <a href="https://discord.gg/wiilink">WiiLink Discord server</a>. for support, you may need to have your Wii Number removed on the database side in order to remedy this issue.

--- a/src/content/guide/demae.md
+++ b/src/content/guide/demae.md
@@ -49,7 +49,7 @@ icon: fa-solid fa-utensils
 
 2. Use the `Get Console ID` Homebrew App that was given by the patcher. This is used to retrieve your system's Console ID.
 
-3. Visit the `#random` channel on the Discord server.
+3. Visit the `#bot-commands` channel on the Discord server.
 
 4. Type the command `/dominos` in the chat, placing your **Console ID** that you got from the **Get Console ID** homebrew app, in the parameter box, otherwise the command will not work and will be posted publicly on the channel.
 


### PR DESCRIPTION
This majorly fixes the Installation page on the main website with a number of both no-brainer and requested fixes.
Some of these fixes include:

- The "Permanent vWii System Settings" priiloader hack has replaced the old and deprecated "Always enable WiiConnect24 for vWii" hack.

- DNS portion has been added to the page (Using the new DNS we now have, not the old one).

- Numerous updates to the look of the page to make it look prettier.

This pull request also fixes a small issue with the Food Channel guide and redo's the entire Wii Message Board guide.