### PR TITLE
Fix Everybody Votes Channel name on en-GB

### DIFF
--- a/public/json/en-GB/services.json
+++ b/public/json/en-GB/services.json
@@ -47,7 +47,7 @@
       },
       {
         "color": "#283688",
-        "name": "<l style='font-size:28px;'>Everybody Votes Channel</l>",
+        "name": "Everybody Votes Channel",
         "desc": "Find out how the world thinks differently from you by taking part in brand new polls.",
         "link": "/guide/evc",
         "isArea": "International",


### PR DESCRIPTION
Hopefully self-explanatory. Found it while browsing the site.