### PR TITLE
Fix services display

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -379,7 +379,7 @@ changeLanguage("en");
       display: none;
     }
     .square {
-      animation: none !important;
+      ;
       border-radius: 0px;
     }
   }


### PR DESCRIPTION
Hopefully this change makes the sliders animate again
For context, here's my issue quoted:



> If you go into dev tools, then sources, then https://www.wiilink24.com/_astro/index.ed21146a.css, then replace
> `@media(prefers-reduced-motion:reduce) {`
> ` .slide-track[data-astro-cid-g5jplrhu] {`
> ` animation: none!important;`
> ` transform: translate(0)`
> ` }`
> with
> `@media(prefers-reduced-motion:reduce) {`
> ` .slide-track[data-astro-cid-g5jplrhu] {`
> ` transform: translate(0)`
> ` }`
> then the sliders start working.
