### PR TITLE
chore(guide/patcher): updated wording on how you get the patcher.

### DIFF
--- a/src/content/guide/patcher.md
+++ b/src/content/guide/patcher.md
@@ -20,7 +20,7 @@ heroImage: "/img/guidebg-1.webp"
 
 ## Installation guide
 
-If you have not done so already, visit the [WiiLink Patcher releases page](https://github.com/WiiLink24/WiiLink-Patcher-GUI/releases) and download the correct patcher for your operating system.
+If you have not done so already, visit the [homepage](https://wiilink.ca) and download the correct patcher for your operating system.
 
 </br>
 


### PR DESCRIPTION
As of writing this, the guide tells the user to go to the Patcher's GUI GitHub page to download the latest version of the patcher. 

While there's isn't anything wrong with it, the download button on the homepage now works, and plus, its already grabbing the latest version of the patcher. Alongside the fact, the website checks the user-agent to see what OS their running. 

So I don't see an issue where we can direct the user to download the patcher there, instead.